### PR TITLE
Ensure partitionKey values match rather than `id` in replaceDocument

### DIFF
--- a/src/account/item-object.ts
+++ b/src/account/item-object.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
-type ItemObject = {
+interface ItemObject {
   id: string;
   indexingPolicy?: {
     indexingMode: string | undefined | null;
@@ -12,7 +12,8 @@ type ItemObject = {
   _rid: string;
   _self: string;
   _ts: number;
-};
+  [key: string]: any;
+}
 
 // eslint-disable-next-line no-undef
 export default ItemObject;

--- a/src/get-partition-key-path.ts
+++ b/src/get-partition-key-path.ts
@@ -1,9 +1,7 @@
 import Collection from "./account/collection";
 
 /**
- * Assumes only 1 partition key path in the following format:
- *  - paths: ["/<partitionKey>"]
- * @returns "<partitionKey>" string or null
+ * @returns string[] of partition key paths for a given collection
  */
 export default function getPartitionKeyPath(collection: Collection) {
   const [firstPath] = collection.read().partitionKey.paths;

--- a/src/get-partition-key-path.ts
+++ b/src/get-partition-key-path.ts
@@ -5,10 +5,10 @@ import Collection from "./account/collection";
  *  - paths: ["/<partitionKey>"]
  * @returns "<partitionKey>" string or null
  */
-export default function getPartitionKey(collection: Collection) {
+export default function getPartitionKeyPath(collection: Collection) {
   const [firstPath] = collection.read().partitionKey.paths;
   if (!firstPath) {
     return null;
   }
-  return firstPath.slice(1); // removes "/" from path
+  return firstPath.slice(1).split("/");
 }

--- a/src/get-partition-key.ts
+++ b/src/get-partition-key.ts
@@ -6,12 +6,7 @@ import Collection from "./account/collection";
  * @returns "<partitionKey>" string or null
  */
 export default function getPartitionKey(collection: Collection) {
-  // eslint-disable-next-line
-  const partitionKey = collection.partitionKeyRanges._parent._data.partitionKey;
-  if (!partitionKey) {
-    return null;
-  }
-  const [firstPath] = partitionKey.paths;
+  const [firstPath] = collection.read().partitionKey.paths;
   if (!firstPath) {
     return null;
   }

--- a/src/get-partition-key.ts
+++ b/src/get-partition-key.ts
@@ -1,0 +1,19 @@
+import Collection from "./account/collection";
+
+/**
+ * Assumes only 1 partition key path in the following format:
+ *  - paths: ["/<partitionKey>"]
+ * @returns "<partitionKey>" string or null
+ */
+export default function getPartitionKey(collection: Collection) {
+  // eslint-disable-next-line
+  const partitionKey = collection.partitionKeyRanges._parent._data.partitionKey;
+  if (!partitionKey) {
+    return null;
+  }
+  const [firstPath] = partitionKey.paths;
+  if (!firstPath) {
+    return null;
+  }
+  return firstPath.slice(1); // removes "/" from path
+}

--- a/src/get-value.ts
+++ b/src/get-value.ts
@@ -1,0 +1,24 @@
+/**
+ * Gets value from an object by following
+ * @param keys path
+ *
+ * Examples:
+ *  > getValue(['foo', 'bar'], { foo: { bar: 1 } })
+ *  => 1
+ *
+ *  > getValue(['foo', 'bar'], {})
+ *  => undefined
+ */
+export default function getValue(
+  keys: string[],
+  obj: { [key: string]: any } | undefined
+): any {
+  if (!obj || keys.length === 0) {
+    return undefined;
+  }
+  const [head, ...tail] = keys;
+  if (tail.length === 0) {
+    return obj[head];
+  }
+  return getValue(tail, obj[head]);
+}

--- a/src/handler/replace-document.ts
+++ b/src/handler/replace-document.ts
@@ -1,5 +1,6 @@
 import * as http from "http";
 import Account from "../account";
+import getPartitionKey from "../get-partition-key";
 import json from "../json";
 
 export default async (
@@ -29,11 +30,15 @@ export default async (
     return {};
   }
 
-  if (data.id !== body.id) {
+  /**
+   * Falling back to `id` partitionKey for now.
+   */
+  const partitionKey = getPartitionKey(collection) || "id";
+  if (data[partitionKey] !== body[partitionKey]) {
     res.statusCode = 400;
     return {
       code: "BadRequest",
-      message: "replacing id is not allowed"
+      message: `replacing partition key "${partitionKey}" is not allowed`
     };
   }
 

--- a/src/handler/replace-document.ts
+++ b/src/handler/replace-document.ts
@@ -1,6 +1,7 @@
 import * as http from "http";
 import Account from "../account";
 import getPartitionKey from "../get-partition-key";
+import getValue from "../get-value";
 import json from "../json";
 
 export default async (
@@ -33,12 +34,14 @@ export default async (
   /**
    * Falling back to `id` partitionKey for now.
    */
-  const partitionKey = getPartitionKey(collection) || "id";
-  if (data[partitionKey] !== body[partitionKey]) {
+  const partitionKeyPath = (getPartitionKey(collection) || "id").split(".");
+  if (getValue(partitionKeyPath, data) !== getValue(partitionKeyPath, body)) {
     res.statusCode = 400;
     return {
       code: "BadRequest",
-      message: `replacing partition key "${partitionKey}" is not allowed`
+      message: `replacing partition key "${partitionKeyPath.join(
+        "."
+      )}" is not allowed`
     };
   }
 

--- a/src/handler/replace-document.ts
+++ b/src/handler/replace-document.ts
@@ -1,6 +1,6 @@
 import * as http from "http";
 import Account from "../account";
-import getPartitionKey from "../get-partition-key";
+import getPartitionKeyPath from "../get-partition-key-path";
 import getValue from "../get-value";
 import json from "../json";
 
@@ -34,7 +34,7 @@ export default async (
   /**
    * Falling back to `id` partitionKey for now.
    */
-  const partitionKeyPath = (getPartitionKey(collection) || "id").split(".");
+  const partitionKeyPath = getPartitionKeyPath(collection) || ["id"];
   if (getValue(partitionKeyPath, data) !== getValue(partitionKeyPath, body)) {
     res.statusCode = 400;
     return {


### PR DESCRIPTION
We need to ensure partitionKey values match rather than `id` when replacing a document. We likely used `id` because in the past we always partitioned by `id`, but this is no longer true and may cause some [cosmos misuse to slip through local tests](https://github.com/vercel/api/blob/master/services/subscriber-transfer-project/src/actions/move-deployment.ts#L37).