### PR TITLE
Support for unique keys

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,8 +13,8 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
     - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
-    - run: npm install
-    - run: npm run lint
-    - run: npm test
+    - run: yarn
+    - run: yarn lint
+    - run: yarn test
     - if: matrix.node == '12.x' && startsWith(github.ref, 'refs/tags/')
       run: npm publish --access public --unsafe-perm

--- a/src/account/collection.ts
+++ b/src/account/collection.ts
@@ -17,7 +17,14 @@ export default class Collection extends Item {
     super(data);
     this.documents = new Documents(
       this,
-      ((data || {}).partitionKey || {}).paths || ["/id"]
+      ((data || {}).partitionKey || {}).paths || ["/id"],
+      (((data || {}).uniqueKeyPolicy || {}).uniqueKeys || []).reduce(
+        (accum: string[], v) => {
+          v.paths.forEach(path => accum.push(path));
+          return accum;
+        },
+        []
+      )
     );
     this.partitionKeyRanges = new PartitionKeyRanges(this, ["/id"]);
     this.userDefinedFunctions = new UserDefinedFunctions(this);
@@ -36,10 +43,10 @@ export default class Collection extends Item {
   }
 
   document(idOrRid: string, partition: PartitionValue) {
-    return this.documents._item(idOrRid, partition);
+    return this.documents._item("/id", idOrRid, partition);
   }
 
   userDefinedFunction(idOrRid: string) {
-    return this.userDefinedFunctions._item(idOrRid, idOrRid);
+    return this.userDefinedFunctions._item("/id", idOrRid, idOrRid);
   }
 }

--- a/src/account/database.ts
+++ b/src/account/database.ts
@@ -12,6 +12,6 @@ export default class Database extends Item {
   }
 
   collection(idOrRid: string) {
-    return this.collections._item(idOrRid, idOrRid);
+    return this.collections._item("/id", idOrRid, idOrRid);
   }
 }

--- a/src/account/index.ts
+++ b/src/account/index.ts
@@ -17,6 +17,6 @@ export default class Account extends Item {
   }
 
   database(idOrRid: string) {
-    return this.databases._item(idOrRid, idOrRid);
+    return this.databases._item("/id", idOrRid, idOrRid);
   }
 }

--- a/src/account/item-object.ts
+++ b/src/account/item-object.ts
@@ -8,6 +8,9 @@ interface ItemObject {
   partitionKey?: {
     paths: string[];
   };
+  uniqueKeyPolicy?: {
+    uniqueKeys: { paths: string[] }[];
+  };
   _etag: string;
   _rid: string;
   _self: string;

--- a/src/account/items.ts
+++ b/src/account/items.ts
@@ -230,19 +230,6 @@ export default class Items<P extends Item, I extends Item> {
     return getValue(this._getPartitionKeyPath(), data);
   }
 
-  _getUniqueKeys(data: { [x: string]: any }): { [key: string]: any } {
-    return this._uniqueKeyPaths.reduce(
-      (a, key) => {
-        const keyPath = key.slice(1).split("/"); // /profile/username -> [profile, username]
-        const value = getValue(keyPath, data);
-        // eslint-disable-next-line
-        a[key] = value;
-        return a;
-      },
-      {} as { [key: string]: any }
-    );
-  }
-
   _getPartitionKeyPath(): string[] {
     const [firstPath] = this._partitionKeyPath;
     if (!firstPath) {

--- a/src/account/user-defined-functions.ts
+++ b/src/account/user-defined-functions.ts
@@ -49,7 +49,7 @@ export default class UserDefinedFunctions extends Items<
   }
 
   replace({ id, body }: { id: string; body: string }) {
-    const oldData = this._item(id, id).read();
+    const oldData = this._item("/id", id, id).read();
     if (!oldData) {
       throw new Error("does not exist");
     }
@@ -69,7 +69,7 @@ export default class UserDefinedFunctions extends Items<
   }
 
   delete(idOrRid: string) {
-    const data = this._item(idOrRid, idOrRid).read();
+    const data = this._item("/id", idOrRid, idOrRid).read();
     if (!data) {
       throw new Error("does not exist");
     }


### PR DESCRIPTION
Ability to pass uniqueKeys for a collection. For example:
```
client.containers.create({
    id: collection,
    partitionKey: {
        paths: [`/userId`],
    },
    uniqueKeyPolicy: {
        uniqueKeys: [{
            paths: ['/name']
        }]
    }
})
```

Creating two documents with same `name` per `userid` (partition) will throw a 409.