### PR TITLE
Checks for unique key existence when replacing document

### DIFF
--- a/src/account/items.ts
+++ b/src/account/items.ts
@@ -148,6 +148,31 @@ export default class Items<P extends Item, I extends Item> {
       throw err;
     }
 
+    this._uniqueKeyPaths.forEach(keyPath => {
+      // No need to check /id here since we explicitly checked it earlier
+      if (keyPath === "/id") {
+        return;
+      }
+
+      const newKeyPathValue = getValue(keyPath.slice(1).split("/"), data);
+      const originalKeyPathValue = getValue(
+        keyPath.slice(1).split("/"),
+        original
+      );
+      if (newKeyPathValue === originalKeyPathValue) {
+        return;
+      }
+
+      if (this._item(keyPath, newKeyPathValue, partition).read()) {
+        const err = new Error(
+          `Resource with specified ${keyPath.slice(1)} already exists.`
+        );
+        // @ts-ignore
+        err.conflict = true;
+        throw err;
+      }
+    });
+
     const { _rid, _self } = oldData;
     const _data = {
       ...data,

--- a/src/account/items.ts
+++ b/src/account/items.ts
@@ -154,11 +154,9 @@ export default class Items<P extends Item, I extends Item> {
         return;
       }
 
-      const newKeyPathValue = getValue(keyPath.slice(1).split("/"), data);
-      const originalKeyPathValue = getValue(
-        keyPath.slice(1).split("/"),
-        original
-      );
+      const keys = keyPath.slice(1).split("/");
+      const newKeyPathValue = getValue(keys, data);
+      const originalKeyPathValue = getValue(keys, original);
       if (newKeyPathValue === originalKeyPathValue) {
         return;
       }

--- a/src/handler/replace-collection.ts
+++ b/src/handler/replace-collection.ts
@@ -42,6 +42,10 @@ export default async (
       res.statusCode = 400;
       return { message: err.message };
     }
+    if (err.conflict) {
+      res.statusCode = 409;
+      return { message: err.message };
+    }
 
     throw err;
   }

--- a/src/handler/replace-collection.ts
+++ b/src/handler/replace-collection.ts
@@ -36,7 +36,7 @@ export default async (
   }
 
   try {
-    return database.collections.replace(body, data);
+    return await database.collections.replace(body, data);
   } catch (err) {
     if (err.badRequest) {
       res.statusCode = 400;
@@ -44,7 +44,7 @@ export default async (
     }
     if (err.conflict) {
       res.statusCode = 409;
-      return { message: err.message };
+      return { message: err.message, code: "Conflict" };
     }
 
     throw err;

--- a/src/handler/replace-document.ts
+++ b/src/handler/replace-document.ts
@@ -42,11 +42,15 @@ export default async (
   }
 
   try {
-    return collection.documents.replace(body, data);
+    return await collection.documents.replace(body, data);
   } catch (error) {
     if (error.badRequest) {
       res.statusCode = 400;
       return { code: "BadRequest", message: error.message };
+    }
+    if (error.conflict) {
+      res.statusCode = 409;
+      return { message: error.message, code: "Conflict" };
     }
     throw error;
   }


### PR DESCRIPTION
Fixes `replace` issue - we now checks for unique key existence when replacing document.