### PR TITLE
Allow a non-SSL listener.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,22 @@ async function runClient() {
 }
 ```
 
+To choose between listening for HTTP and HTTPS, import the right function.
+
+```js
+const { createHttpServer, createHttpsServer } = require("@zeit/cosmosdb-server"); 
+```
+
 To run the server on cli:
 
 ```sh
 cosmosdb-server -p 3000
+```
+
+or without SSL:
+
+```sh
+cosmosdb-server -p 3000 --no-ssl
 ```
 
 ## installation

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 import * as net from "net";
-import cosmosDBServer from ".";
+import { createHttpServer, createHttpsServer } from ".";
 
 const argv = process.argv.slice(2);
-const args: { help?: boolean; port?: number; hostname?: string } = {};
+const args: {
+  help?: boolean;
+  port?: number;
+  hostname?: string;
+  nossl?: boolean;
+} = {};
 while (argv.length) {
   const key = argv.shift();
   switch (key) {
@@ -17,6 +22,9 @@ while (argv.length) {
       break;
     case "--host":
       args.hostname = argv.shift();
+      break;
+    case "--no-ssl":
+      args.nossl = true;
       break;
     default:
       break;
@@ -32,11 +40,13 @@ Options:
 
   -h, --help
   -p, --port
+  --no-ssl
   --host
 `);
   process.exit();
 }
 
+const cosmosDBServer = args.nossl ? createHttpServer : createHttpsServer;
 const server = cosmosDBServer().listen(args.port, args.hostname, () => {
   const { address, family, port } = server.address() as net.AddressInfo;
   // eslint-disable-next-line no-nested-ternary
@@ -46,5 +56,9 @@ const server = cosmosDBServer().listen(args.port, args.hostname, () => {
     ? `[${address}]`
     : address;
   // eslint-disable-next-line no-console
-  console.log(`Ready to accept connections at ${hostname}:${port}`);
+  console.log(
+    `Ready to accept HTTP${
+      args.nossl ? "" : "S"
+    } connections at ${hostname}:${port}`
+  );
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "fs";
-import { createServer, ServerOptions } from "https";
+import * as http from "http";
+import * as https from "https";
 import * as net from "net";
 import { join } from "path";
 import * as tls from "tls";
@@ -7,85 +8,112 @@ import uuid from "uuid/v4";
 import Account from "./account";
 import routes from "./routes";
 
-const options: ServerOptions = {
-  cert: readFileSync(join(__dirname, "..", "cert.pem")),
-  key: readFileSync(join(__dirname, "..", "key.pem")),
-  minVersion: "TLSv1" as tls.SecureVersion,
-  rejectUnauthorized: false,
-  requestCert: false
-};
+const handleRequest = (
+  account: Account,
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+) => {
+  const route = routes(req);
 
-export default (opts?: ServerOptions) => {
-  let account: Account | undefined;
-
-  const server = createServer({ ...options, ...opts }, (req, res) => {
-    const route = routes(req);
-
-    (async () => {
-      let body;
-      if (route) {
-        const [params, handler] = route;
-        try {
-          body = await handler(account, req, res, params);
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.error(err);
-          body = { message: err.message };
-          res.statusCode = 500;
-        }
-        if (res.statusCode > 399 && !body.message) {
-          body.message = "";
-        }
-      } else {
-        res.statusCode = 400;
-        body = { message: "no route" };
-      }
-
-      if (body && body._etag) {
-        res.setHeader("etag", body._etag);
-      }
-
-      res.setHeader("content-type", "application/json");
-      res.setHeader(
-        "content-location",
-        `https://${req.headers.host}${req.url}`
-      );
-      res.setHeader("connection", "close");
-      res.setHeader("x-ms-activity-id", uuid());
-      res.setHeader("x-ms-request-charge", "1");
-      if (req.headers["x-ms-documentdb-populatequerymetrics"]) {
-        res.setHeader(
-          "x-ms-documentdb-query-metrics",
-          "totalExecutionTimeInMs=0.00;queryCompileTimeInMs=0.00;queryLogicalPlanBuildTimeInMs=0.00;queryPhysicalPlanBuildTimeInMs=0.00;queryOptimizationTimeInMs=0.00;VMExecutionTimeInMs=0.00;indexLookupTimeInMs=0.00;documentLoadTimeInMs=0.00;systemFunctionExecuteTimeInMs=0.00;userFunctionExecuteTimeInMs=0.00;retrievedDocumentCount=0;retrievedDocumentSize=0;outputDocumentCount=1;outputDocumentSize=0;writeOutputTimeInMs=0.00;indexUtilizationRatio=0.00"
-        );
-      }
-
-      if (req.headers["a-im"] && res.statusCode === 200) {
-        if (req.headers["if-none-match"]) {
-          res.statusCode = 304;
-        }
-        res.setHeader("etag", "1");
-      }
-      res.end(JSON.stringify(body));
-    })().catch(err => {
-      // eslint-disable-next-line no-console
-      console.error(err);
-      if (!res.finished) {
+  (async () => {
+    let body;
+    if (route) {
+      const [params, handler] = route;
+      try {
+        body = await handler(account, req, res, params);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+        body = { message: err.message };
         res.statusCode = 500;
-        res.end("");
       }
-    });
-  }).on("listening", () => {
-    const address = server.address();
-    if (typeof address === "object" && address) {
-      const { address: host, port } = address as net.AddressInfo;
-      const hostname = host === "0.0.0.0" || host === "::" ? "localhost" : host;
-
-      account = new Account(hostname, port);
+      if (res.statusCode > 399 && !body.message) {
+        body.message = "";
+      }
     } else {
-      throw new Error(`Unexpected address type: ${address}`);
+      res.statusCode = 400;
+      body = { message: "no route" };
+    }
+
+    if (body && body._etag) {
+      res.setHeader("etag", body._etag);
+    }
+
+    res.setHeader("content-type", "application/json");
+    res.setHeader("content-location", `https://${req.headers.host}${req.url}`);
+    res.setHeader("connection", "close");
+    res.setHeader("x-ms-activity-id", uuid());
+    res.setHeader("x-ms-request-charge", "1");
+    if (req.headers["x-ms-documentdb-populatequerymetrics"]) {
+      res.setHeader(
+        "x-ms-documentdb-query-metrics",
+        "totalExecutionTimeInMs=0.00;queryCompileTimeInMs=0.00;queryLogicalPlanBuildTimeInMs=0.00;queryPhysicalPlanBuildTimeInMs=0.00;queryOptimizationTimeInMs=0.00;VMExecutionTimeInMs=0.00;indexLookupTimeInMs=0.00;documentLoadTimeInMs=0.00;systemFunctionExecuteTimeInMs=0.00;userFunctionExecuteTimeInMs=0.00;retrievedDocumentCount=0;retrievedDocumentSize=0;outputDocumentCount=1;outputDocumentSize=0;writeOutputTimeInMs=0.00;indexUtilizationRatio=0.00"
+      );
+    }
+
+    if (req.headers["a-im"] && res.statusCode === 200) {
+      if (req.headers["if-none-match"]) {
+        res.statusCode = 304;
+      }
+      res.setHeader("etag", "1");
+    }
+    res.end(JSON.stringify(body));
+  })().catch(err => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    if (!res.finished) {
+      res.statusCode = 500;
+      res.end("");
     }
   });
+};
+
+const createAccount = (address: string | net.AddressInfo) => {
+  if (!address || typeof address !== "object") {
+    throw new Error(`Unexpected address type: ${address}`);
+  }
+
+  const { address: host, port } = address as net.AddressInfo;
+  const hostname = host === "0.0.0.0" || host === "::" ? "localhost" : host;
+
+  return new Account(hostname, port);
+};
+
+export function createHttpServer(opts?: http.ServerOptions) {
+  let account: Account | undefined;
+
+  const server = http
+    .createServer(opts, (req, res) => {
+      handleRequest(account, req, res);
+    })
+    .on("listening", () => {
+      account = createAccount(server.address());
+    });
 
   return server;
-};
+}
+
+export function createHttpsServer(opts?: https.ServerOptions) {
+  let account: Account | undefined;
+
+  const options: https.ServerOptions = {
+    cert: readFileSync(join(__dirname, "..", "cert.pem")),
+    key: readFileSync(join(__dirname, "..", "key.pem")),
+    minVersion: "TLSv1" as tls.SecureVersion,
+    rejectUnauthorized: false,
+    requestCert: false,
+    ...opts
+  };
+
+  const server = https
+    .createServer(options, (req, res) => {
+      handleRequest(account, req, res);
+    })
+    .on("listening", () => {
+      account = createAccount(server.address());
+    });
+
+  return server;
+}
+
+export default createHttpsServer;


### PR DESCRIPTION
This is useful when something else (e.g. an ALB) is doing SSL offloading