### PR TITLE
Add support for keep-alive

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@azure/cosmos": "3.10.2",
     "@babel/core": "7.6.2",
     "@types/lru-cache": "5.1.0",
-    "@types/node": "12.7.9",
+    "@types/node": "^16.0.0",
     "@types/uuid": "3.4.5",
     "@typescript-eslint/eslint-plugin": "2.3.2",
     "@typescript-eslint/parser": "2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,15 +1511,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*":
-  version "12.0.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.10.tgz#51babf9c7deadd5343620055fc8aff7995c8b031"
-  integrity sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==
-
-"@types/node@12.7.9":
-  version "12.7.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.9.tgz#da0210f91096aa67138cf5afd04c4d629f8a406a"
-  integrity sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ==
+"@types/node@*", "@types/node@^16.0.0":
+  version "16.18.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.14.tgz#5465ce598486a703caddbefe8603f8a2cffa3461"
+  integrity sha512-wvzClDGQXOCVNU4APPopC2KtMYukaF1MN/W3xAmslx22Z4/IF1/izDMekuyoUlwfnDHYCIZGaj7jMwnJKBTxKw==
 
 "@types/tunnel@^0.0.1":
   version "0.0.1"


### PR DESCRIPTION
This adds support for `keep-alive` connections to the server.

Also it upgrades `@types/node` to latest LTS as we use the native `http.ServerOptions` `keepAlive` setting for that that is available since `16.5.x` release of Node.js.