### PR TITLE
bump path-to-regexp to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "big-integer": "1.6.46",
     "int64-buffer": "0.99.1007",
     "lru-cache": "6.0.0",
-    "path-to-regexp": "3.1.0",
+    "path-to-regexp": "3.3.0",
     "raw-body": "2.4.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5126,10 +5126,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.1.0.tgz#f45a9cc4dc6331ae8f131e0ce4fde8607f802367"
-  integrity sha512-PtHLisEvUOepjc+sStXxJ/pDV/s5UBTOKWJY2SOz3e6E/iN/jLknY9WL72kTwRrwXDUbZTEAtSnJbz2fF127DA==
+path-to-regexp@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz#f7f31d32e8518c2660862b644414b6d5c63a611b"
+  integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
 
 path-type@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
There is a vulnerability in the package `path-to-regexp`, we use `cosmosdb-server` in our pipelines which are failing due to this issue.

https://github.com/advisories/GHSA-9wv6-86v2-598j

<img width="647" alt="image" src="https://github.com/user-attachments/assets/9401aacf-bd6b-4b3e-b8be-920a657012a4">

![image](https://github.com/user-attachments/assets/4f9340ea-fc37-4d54-a6a2-da3a9b15c2f6)
